### PR TITLE
chore!: don't publish flow source as jsnext:main

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,9 @@
     "node": ">= 6.0.0"
   },
   "files": [
-    "lib/",
-    "src/"
+    "lib/"
   ],
   "homepage": "https://github.com/exodusmovement/varstruct-cstringr#readme",
-  "jsnext:main": "./src/index.js",
   "keywords": [
     "varstruct",
     "cstring",


### PR DESCRIPTION
`jsnext:main` isn't used much anymore, and raw flow sources don't make sense here anyhow.

BREAKING CHANGE